### PR TITLE
사용자 인증을 위한 이메일 서비스 구현 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,14 +50,31 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-tomcat</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jstl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-jasper</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-data-redis</artifactId>
+			<version>2.1.3.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -71,28 +88,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-taglibs</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.session</groupId>
-			<artifactId>spring-session-data-redis</artifactId>
-			<version>2.1.3.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-jasper</artifactId>
-			<scope>provided</scope>
-		</dependency>
-        <dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-		</dependency>
 		<!-- BootStrap -->
 		<dependency>
 			<groupId>org.webjars</groupId>
@@ -103,6 +98,11 @@
 			<groupId>org.webjars</groupId>
 			<artifactId>jquery</artifactId>
 			<version>3.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+			<version>1.4.3.RELEASE</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>jstl</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-jasper</artifactId>

--- a/src/main/java/net/hyerin/config/redis/RedisConfig.java
+++ b/src/main/java/net/hyerin/config/redis/RedisConfig.java
@@ -26,8 +26,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());

--- a/src/main/java/net/hyerin/config/redis/RedisConfig.java
+++ b/src/main/java/net/hyerin/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package net.hyerin.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@Configuration
+@EnableRedisHttpSession
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/net/hyerin/config/security/SecurityConfig.java
+++ b/src/main/java/net/hyerin/config/security/SecurityConfig.java
@@ -1,21 +1,63 @@
 package net.hyerin.config.security;
 
+import net.hyerin.user.service.MyAuthenticationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity // 웹 보안을 활성화
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-//     @Override
-//     public void configure(WebSecurity web) throws Exception { }
+    @Autowired
+    MyAuthenticationProvider myAuthenticationProvider;
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/res/**");
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .antMatchers("/test/**").permitAll();
+                .antMatchers("/test/**").permitAll()
+                .antMatchers("/users/signup").permitAll()
+                .antMatchers("/users/signupSuccess").permitAll()
+                .antMatchers("/users/signin").permitAll()
+                .antMatchers("/users/email").permitAll()
+                .antMatchers("/users/email/**").permitAll()
+                .antMatchers("/auth/**").permitAll()
+                .antMatchers("/").permitAll()
+                .antMatchers("/**").authenticated();
+
+        http.csrf().disable();
+
+        // TODO JSP 구현 후 작성 예정
+        http.formLogin()
+                .loginPage("/users/signin")
+                .loginProcessingUrl("/users/signin_processing")
+                .failureUrl("/users/signin?error")
+                .defaultSuccessUrl("/users/profile", true)
+                .usernameParameter("email")
+                .passwordParameter("password");
+
+        http.logout()
+                .logoutRequestMatcher(new AntPathRequestMatcher("/users/logout_processing"))
+                .logoutSuccessUrl("/users/signin")
+                .invalidateHttpSession(true);
+
+        http.authenticationProvider(myAuthenticationProvider);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/net/hyerin/config/security/SecurityConfig.java
+++ b/src/main/java/net/hyerin/config/security/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/test/**").permitAll()
                 .antMatchers("/users/signup").permitAll()
                 .antMatchers("/users/signupSuccess").permitAll()
+                .antMatchers("/users/signupFail").permitAll()
                 .antMatchers("/users/signin").permitAll()
                 .antMatchers("/users/email").permitAll()
                 .antMatchers("/users/email/**").permitAll()

--- a/src/main/java/net/hyerin/email/service/EmailService.java
+++ b/src/main/java/net/hyerin/email/service/EmailService.java
@@ -1,0 +1,6 @@
+package net.hyerin.email.service;
+
+public interface EmailService {
+    public void sendMail(String email);
+    public boolean isMatchVerifyCode(String email, String code);
+}

--- a/src/main/java/net/hyerin/email/service/EmailService.java
+++ b/src/main/java/net/hyerin/email/service/EmailService.java
@@ -1,6 +1,11 @@
 package net.hyerin.email.service;
 
+import javax.mail.MessagingException;
+import javax.mail.SendFailedException;
+
 public interface EmailService {
-    public void sendMail(String email);
+    public void sendMail(String email) throws Exception;
     public boolean isMatchVerifyCode(String email, String code);
+    public String generateVerificationCode();
+    public String generateVerificationText(String email, String code);
 }

--- a/src/main/java/net/hyerin/email/service/EmailServiceImpl.java
+++ b/src/main/java/net/hyerin/email/service/EmailServiceImpl.java
@@ -14,8 +14,7 @@ import javax.mail.internet.MimeMessage;
 @Service("emailService")
 public class EmailServiceImpl implements EmailService {
 
-    @Value("${spring.mail.username}")
-    private static String sender;
+    private static final String SENDER = "litebook.official@gmail.com";
 
     @Autowired
     private JavaMailSender javaMailSender;
@@ -25,15 +24,14 @@ public class EmailServiceImpl implements EmailService {
 
     @Override
     public void sendMail(String email) {
-
         MimeMessage msg = javaMailSender.createMimeMessage();
         MimeMessageHelper helper;
-
         try {
             // 메일 전송
             String code = generateVerificationCode();
             helper = new MimeMessageHelper(msg, false, "UTF-8");
-            helper.setTo(sender);
+            helper.setFrom(SENDER);
+            helper.setTo(email);
             helper.setSubject("[litebook] 이메일 인증");
             helper.setText(generateVerificationText(email, code), true);
             javaMailSender.send(msg);
@@ -56,12 +54,11 @@ public class EmailServiceImpl implements EmailService {
         return Integer.toString((int)(Math.random() * 899999) + 100000);
     }
 
-    // 이미지 미완성, 우선 이미지 아이콘으로 전송됨
     private static String generateVerificationText(String email, String code){
         return "<html><body><p2>인증을 위해 아래 링크를 클릭해 주세요.</p2>" +
                 "<p>이메일 인증 후 로그인이 가능합니다.</p>" +
                 "<a href='http://localhost:8080/users/email/verify?email=" + email +
-                "&code=" + code + "'>" + "<img src='/Users/hyerin/Desktop/authImg.png'/></a>" +
-                "<p>위에 있는 이미지 클릭하면 인증 화면으로 넘어갑니다.</p></body></html>";
+                "&code=" + code + "'>" +
+                "<p>이 링크를 클릭하세요.</p></body></html>";
     }
 }

--- a/src/main/java/net/hyerin/email/service/EmailServiceImpl.java
+++ b/src/main/java/net/hyerin/email/service/EmailServiceImpl.java
@@ -1,0 +1,67 @@
+package net.hyerin.email.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.mail.internet.MimeMessage;
+
+@Slf4j
+@Service("emailService")
+public class EmailServiceImpl implements EmailService {
+
+    @Value("${spring.mail.username}")
+    private static String sender;
+
+    @Autowired
+    private JavaMailSender javaMailSender;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void sendMail(String email) {
+
+        MimeMessage msg = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper;
+
+        try {
+            // 메일 전송
+            String code = generateVerificationCode();
+            helper = new MimeMessageHelper(msg, false, "UTF-8");
+            helper.setTo(sender);
+            helper.setSubject("[litebook] 이메일 인증");
+            helper.setText(generateVerificationText(email, code), true);
+            javaMailSender.send(msg);
+
+            // <이메일, 인증코드> 레디스에 저장
+            redisTemplate.opsForValue().set(email, code);
+        } catch(Exception e){
+            log.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isMatchVerifyCode(String email, String code) {
+        if(code.equals(redisTemplate.opsForValue().get(email)))
+            return true;
+        return false;
+    }
+
+    private static String generateVerificationCode() { // 6자리 인증 코드 생성
+        return Integer.toString((int)(Math.random() * 899999) + 100000);
+    }
+
+    // 이미지 미완성, 우선 이미지 아이콘으로 전송됨
+    private static String generateVerificationText(String email, String code){
+        return "<html><body><p2>인증을 위해 아래 링크를 클릭해 주세요.</p2>" +
+                "<p>이메일 인증 후 로그인이 가능합니다.</p>" +
+                "<a href='http://localhost:8080/users/email/verify?email=" + email +
+                "&code=" + code + "'>" + "<img src='/Users/hyerin/Desktop/authImg.png'/></a>" +
+                "<p>위에 있는 이미지 클릭하면 인증 화면으로 넘어갑니다.</p></body></html>";
+    }
+}

--- a/src/main/java/net/hyerin/test/TestController.java
+++ b/src/main/java/net/hyerin/test/TestController.java
@@ -1,14 +1,21 @@
 package net.hyerin.test;
 
 import lombok.extern.slf4j.Slf4j;
+import net.hyerin.email.service.EmailService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @Controller
 @RequestMapping("/test")
 public class TestController {
+
+    @Autowired
+    EmailService emailService;
 
     // 로그인 화면 확인을 위한 메소드
     @GetMapping("signin")
@@ -29,6 +36,13 @@ public class TestController {
     public String profile() {
         log.info("users/profile");
         return "users/profile";
+    }
+
+    // 이메일 전송 테스트를 위한 메소드
+    @GetMapping("email")
+    public String emailSend(){
+        emailService.sendMail("hyerinn6@gmail.com");
+        return "users/signupSuccess";
     }
 
 }

--- a/src/main/webapp/WEB-INF/views/auth/fail.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/fail.jsp
@@ -1,0 +1,16 @@
+<%@ page pageEncoding="utf-8"%>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>lite book</title>
+</head>
+<body>
+<script type="text/javascript">
+    alert('인증 실패');
+    window.open('', '_self', '');
+    window.close();
+</script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/auth/success.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/success.jsp
@@ -1,0 +1,16 @@
+<%@ page pageEncoding="utf-8"%>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>lite book</title>
+</head>
+<body>
+<script type="text/javascript">
+    alert('인증 성공 ! 이제 로그인이 가능 합니다.');
+    window.open('', '_self', '');
+    window.close();
+</script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/users/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/users/signup.jsp
@@ -1,68 +1,63 @@
-<%@ page pageEncoding="utf-8"%>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
-<%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+<%@ taglib uri="http://www.springframework.org/security/tags" prefix="sec" %>
 <c:url var="R" value="/" />
 <link rel="stylesheet" href="${R}res/signup.css">
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
-    <meta charset="utf-8">
-    <!--  This file has been downloaded from https://bootdey.com  -->
-    <!--  All snippets are MIT license https://bootdey.com/license -->
-    <title>lite book</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-    <link href="http://netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <style> .error { color: red; }</style>
 </head>
 <body>
-<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
 <div class="signup-container animated fadeInDown bootstrap snippets">
-    <div class="signupbox bg-white">
-        <br/><br/>
-        <div class="signupbox-title">lite book</div>
-        <div class="signupbox-title2">Create A New Account</div>
-        <br/><br/>
-
+<div class="signupbox bg-white"><br/><br/>
+<div class="signupbox-title">lite book</div>
+<div class="signupbox-title2">Create A New Account</div><br/>
+<div class="form-group">
+    <form:form method="post" modelAttribute="userSignupDto" action="/users/signup" enctype="multipart/form-data">
         <div class="signupbox-textbox">
-            <label>Email</label>
-            <input type="email" class="form-control" placeholder="Email">
-        </div>
-        <div class="signupbox-textbox">
-            <label>Password</label>
-            <input type="password" class="form-control" placeholder="Password">
+            <form:label path="email">Email</form:label>
+            <form:input path="email" class="form-control" placeholder="Email"/>
+            <form:errors path="email" class="error" />
         </div>
         <div class="signupbox-textbox">
-            <label>Password</label>
-            <input type="password" class="form-control" placeholder="Password">
+            <form:label path="password1">Password</form:label>
+            <form:password path="password1" class="form-control" placeholder="Password" />
+            <form:errors path="password1" class="error" />
         </div>
         <div class="signupbox-textbox">
-            <label>Name</label>
-            <input type="text" class="form-control" placeholder="Name">
+            <form:label path="password2">Password</form:label>
+            <form:password path="password2" class="form-control" placeholder="Password" />
+            <form:errors path="password2" class="error" />
         </div>
         <div class="signupbox-textbox">
-            <label>Phone</label>
-            <input type="text" class="form-control" placeholder="Phone">
+            <form:label path="name">Name</form:label>
+            <form:input path="name" class="form-control" placeholder="Name" />
+            <form:errors path="name" class="error" />
         </div>
         <div class="signupbox-textbox">
-            <label>Profile</label>
-            <input type="file" class="form-control" placeholder="Profile">
+            <form:label path="phone">Phone</form:label>
+            <form:input path="phone" class="form-control" placeholder="Phone" />
+            <form:errors path="phone" class="error" />
         </div>
-        <div class="signupbox-submit">
-            <input type="button" class="btn btn-primary btn-block" value="Sign up">
+        <div class="signupbox-textbox">
+            <form:label path="profile">Profile</form:label>
+            <input type="file" class="form-control" placeholder="Profile" path="profile" />
         </div>
-
-
-    </div>
-    <div class="logobox">
-    </div>
+        <div class="signupbox-textbox">
+            <button type="submit" class="btn btn-primary btn-block">
+                <i class="glyphicon glyphicon-user"></i> Sign up
+            </button>
+        </div>
+    </form:form>
 </div>
-
-<script src="http://netdna.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-<script type="text/javascript">
-
-</script>
+</div>
+</div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/users/signupFail.jsp
+++ b/src/main/webapp/WEB-INF/views/users/signupFail.jsp
@@ -1,0 +1,15 @@
+<%@ page pageEncoding="utf-8"%>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>lite book</title>
+</head>
+<body>
+<script type="text/javascript">
+    alert('이메일 전송에 실패했습니다. 다시 확인해주세요.');
+    window.close();
+</script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/users/signupSuccess.jsp
+++ b/src/main/webapp/WEB-INF/views/users/signupSuccess.jsp
@@ -1,0 +1,15 @@
+<%@ page pageEncoding="utf-8"%>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>lite book</title>
+</head>
+<body>
+<script type="text/javascript">
+    alert('회원가입 성공 ! 이메일 인증 후 로그인 가능합니다.');
+    window.close();
+</script>
+</body>
+</html>


### PR DESCRIPTION
### 이메일 인증    
controller, userService 는 회원가입 기능 issue로..  

- 이메일 본문에 인증 코드 6자리를 담은 url 링크가 삽입되어 전달됩니다.   

- 이메일 인증이 성공하면 완료 메시지가 출력됩니다.   

- 이메일 인증에 실패하면 실패 메시지가 출력됩니다.   

- 이메일 인증 코드는 사용자 이메일과 함께 redis에 `<email, code>` 로 저장됩니다.   

- 인증이 완료되면 사용자의 `userType`은 `IS_AUTHENTICATED_FULLY`로 변경되고   
`enabled`는 `true`로 변경됩니다.   