### PR TITLE
[#54] Sign up, Sign in 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,8 @@
 # litebook
-Social Network Service (Timeline)    
+
+Social Network Service (Timeline)
 
 친구와 가족, 같은 관심사를 가진 사람들과 소통할 수 있는     
 좋아하는 컨텐츠 업로더를 구독하거나 나의 이야기를 공유할 수 있는 서비스입니다.     
 
-<br />   
 
-### 프로젝트 진행 과정   
-- 블로그 포스팅   
-  + 커서 기반 페이징 구현 : <https://hyerin6.github.io/2020-07-14/0714/>    
-  + JPA 연관관계 : <https://hyerin6.github.io/2020-04-26/0506/>      
-  + jsp 404 not found 해결 : <https://hyerin6.github.io/2020-04-26/0426/>     
-  + Jenkins 설치 및 설정 : <https://hyerin6.github.io/2020-04-21/0421/>      
-  + Jenkins와 Redis 사용 설정 : <https://hyerin6.github.io/2020-04-24/0424/>       
-  + Spring Security : <https://hyerin6.github.io/2020-04-17/0417/>   
-  + 생성자 주입(Constructor Injection) 권장 이유 : <https://hyerin6.github.io/2020-04-13/0413/>    
-  + Lombok, Interface, Factory Method 장점 : <https://hyerin6.github.io/2020-04-05/0405/>     
-  + validation : <https://hyerin6.github.io/2020-02-14/spring-form-validation/>    
-  + Naming, spring 표준 권한 : <https://hyerin6.github.io/2020-04-03/0403/>   
-<br />     
-  
-- DB 설계 과정 보러가기 : [wiki](https://github.com/hyerin6/litebook/wiki/DB-%EC%84%A4%EA%B3%84)      
-
-<br />   
-
-### 시연 영상     
-- [1차 릴리즈 시연 영상](https://youtu.be/R466EUkHROQ)  
-- [2차 릴리즈 시연 영상](https://youtu.be/EyKL24FIm0U)  
-- [3차 릴리즈 시연 영상](https://youtu.be/OaW38Hp6e6E)     

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'org.springframework.boot' version '2.3.9.RELEASE'
-	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-	id 'java'
+    id 'org.springframework.boot' version '2.3.9.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'java'
 }
 
 group = 'com.hyerin'
@@ -9,29 +9,32 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	jcenter()
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'mysql:mysql-connector-java'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation('org.springframework.boot:spring-boot-starter-test') {
-		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-	}
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'mysql:mysql-connector-java'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 test {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/hyerin/litebook/auth/controller/AuthController.java
+++ b/src/main/java/com/hyerin/litebook/auth/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.hyerin.litebook.auth.controller;
+
+import static com.hyerin.litebook.common.dto.ResponseEntityConstants.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hyerin.litebook.auth.thirdparty.dto.SignInRequest;
+import com.hyerin.litebook.auth.thirdparty.dto.SignUpRequest;
+import com.hyerin.litebook.auth.thirdparty.service.SocialAuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+	private final SocialAuthService kakaoAuthService;
+
+	@GetMapping("/third-parties/kakao/sign-up")
+	public ResponseEntity<Void> kakaoSignUp(@RequestParam("code") String code) {
+		kakaoAuthService.signUp(new SignUpRequest(code));
+		return CREATED;
+	}
+
+	@PostMapping("/third-parties/kakao/sign-in")
+	public ResponseEntity<Void> kakaoSignIn(@RequestBody SignInRequest request) {
+		try {
+			kakaoAuthService.signIn(request);
+		} catch (Exception e) {
+			return BAD_REQUEST;
+		}
+		return OK;
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/controller/AuthController.java
+++ b/src/main/java/com/hyerin/litebook/auth/controller/AuthController.java
@@ -36,6 +36,7 @@ public class AuthController {
 		} catch (Exception e) {
 			return BAD_REQUEST;
 		}
+		
 		return OK;
 	}
 

--- a/src/main/java/com/hyerin/litebook/auth/service/LoginService.java
+++ b/src/main/java/com/hyerin/litebook/auth/service/LoginService.java
@@ -1,0 +1,5 @@
+package com.hyerin.litebook.auth.service;
+
+public interface LoginService {
+	void login(String uid);
+}

--- a/src/main/java/com/hyerin/litebook/auth/service/SessionLoginService.java
+++ b/src/main/java/com/hyerin/litebook/auth/service/SessionLoginService.java
@@ -1,0 +1,22 @@
+package com.hyerin.litebook.auth.service;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SessionLoginService implements LoginService {
+
+	private static final String SESSION_LOGIN_KEY = "UID";
+
+	private final HttpSession httpSession;
+
+	@Override
+	public void login(String uid) {
+		httpSession.setAttribute(SESSION_LOGIN_KEY, uid);
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/dto/SignInRequest.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/dto/SignInRequest.java
@@ -1,0 +1,14 @@
+package com.hyerin.litebook.auth.thirdparty.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignInRequest {
+
+	private String uid;
+
+	private String accessToken;
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/dto/SignUpRequest.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/dto/SignUpRequest.java
@@ -1,0 +1,12 @@
+package com.hyerin.litebook.auth.thirdparty.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignUpRequest {
+
+	private String code;
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/api/KakaoAuthApiService.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/api/KakaoAuthApiService.java
@@ -1,0 +1,57 @@
+package com.hyerin.litebook.auth.thirdparty.kakao.api;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.hyerin.litebook.auth.thirdparty.kakao.dto.KakaoProfileResponse;
+import com.hyerin.litebook.auth.thirdparty.kakao.dto.KakaoTokenResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@PropertySource("classpath:/auth.properties")
+@RequiredArgsConstructor
+@Component
+public class KakaoAuthApiService {
+
+	@Value("${kakao.access.token.url}")
+	private String KAKAO_ACCESS_TOKEN_URL;
+
+	@Value("${kakao.profile.url}")
+	private String KAKAO_PROFILE_URL;
+
+	private final WebClient apiWebClient;
+
+	public KakaoTokenResponse getKakaoAccessToken(String code) {
+		return apiWebClient.post()
+			.uri(KAKAO_ACCESS_TOKEN_URL.concat(code))
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.retrieve()
+			.bodyToMono(KakaoTokenResponse.class)
+			.block();
+	}
+
+	public KakaoProfileResponse getKakaoProfile(String token) {
+		return apiWebClient.get()
+			.uri(KAKAO_PROFILE_URL)
+			.headers(headers -> headers.setBearerAuth(token))
+			.retrieve()
+			.onStatus(status -> status.is4xxClientError(),
+				response -> response.bodyToMono(KakaoErrorResponse.class)
+					.map(body -> new IllegalArgumentException(body.getMsg())))
+			.bodyToMono(KakaoProfileResponse.class)
+			.block();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	static class KakaoErrorResponse {
+		private int code;
+		private String msg;
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoAccount.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoAccount.java
@@ -1,0 +1,21 @@
+package com.hyerin.litebook.auth.thirdparty.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoAccount {
+
+	private Profile profile;
+	private String email;
+
+	@Getter
+	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+	public static class Profile {
+		private String nickname;
+		private String profileImageUrl;
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoProfileResponse.java
@@ -1,0 +1,21 @@
+package com.hyerin.litebook.auth.thirdparty.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class KakaoProfileResponse {
+
+	private Long id;
+
+	private KakaoAccount kakaoAccount;
+
+	public String getId() {
+		return id.toString();
+	}
+
+	public KakaoAccount getKakaoAccount() {
+		return kakaoAccount;
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,19 @@
+package com.hyerin.litebook.auth.thirdparty.kakao.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class KakaoTokenResponse {
+
+	private String tokenType;
+	private String accessToken;
+	private Integer expiresIn;
+	private String refreshToken;
+	private Integer refreshTokenExpiresIn;
+	private String scope;
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -39,7 +39,7 @@ public class KakaoAuthService implements SocialAuthService<SignUpRequest, SignIn
 			.name(kakaoProfile.getKakaoAccount().getProfile().getNickname())
 			.profile(kakaoProfile.getKakaoAccount().getProfile().getProfileImageUrl())
 			.build();
-
+		
 		userService.signUp(user);
 	}
 

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -1,0 +1,60 @@
+package com.hyerin.litebook.auth.thirdparty.kakao.service;
+
+import javax.servlet.http.HttpSession;
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.hyerin.litebook.auth.thirdparty.dto.SignInRequest;
+import com.hyerin.litebook.auth.thirdparty.dto.SignUpRequest;
+import com.hyerin.litebook.auth.thirdparty.kakao.api.KakaoAuthApiService;
+import com.hyerin.litebook.auth.thirdparty.kakao.dto.KakaoProfileResponse;
+import com.hyerin.litebook.auth.thirdparty.kakao.dto.KakaoTokenResponse;
+import com.hyerin.litebook.auth.thirdparty.service.SocialAuthService;
+import com.hyerin.litebook.user.domain.User;
+import com.hyerin.litebook.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService implements SocialAuthService<SignUpRequest, SignInRequest> {
+
+	private static final String SESSION_LOGIN_KEY = "UID";
+	private static final String BAD_REQUEST = "BAD REQUEST : ";
+
+	private final KakaoAuthApiService kakaoAuthApiService;
+	private final UserService userService;
+	private final HttpSession httpSession;
+
+	@Override
+	@Transactional
+	public void signUp(SignUpRequest request) {
+		KakaoTokenResponse kakaoTokenResponse = kakaoAuthApiService.getKakaoAccessToken(request.getCode());
+		KakaoProfileResponse kakaoProfile = kakaoAuthApiService.getKakaoProfile(kakaoTokenResponse.getAccessToken());
+
+		User user = User.builder()
+			.uid(kakaoProfile.getId())
+			.email(kakaoProfile.getKakaoAccount().getEmail())
+			.name(kakaoProfile.getKakaoAccount().getProfile().getNickname())
+			.profile(kakaoProfile.getKakaoAccount().getProfile().getProfileImageUrl())
+			.build();
+
+		userService.signUp(user);
+	}
+
+	@Override
+	public void signIn(SignInRequest request) throws Exception {
+		KakaoProfileResponse kakaoProfile = kakaoAuthApiService.getKakaoProfile(request.getAccessToken());
+		User user = userService.getUser(request.getUid());
+
+		if (kakaoProfile.getId().equals(user.getUid())) {
+			httpSession.setAttribute(SESSION_LOGIN_KEY, user.getUid());
+			return;
+		} else {
+			throw new IllegalArgumentException(BAD_REQUEST.concat(request.getUid()));
+		}
+
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/kakao/service/KakaoAuthService.java
@@ -1,10 +1,10 @@
 package com.hyerin.litebook.auth.thirdparty.kakao.service;
 
-import javax.servlet.http.HttpSession;
 import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
 
+import com.hyerin.litebook.auth.service.LoginService;
 import com.hyerin.litebook.auth.thirdparty.dto.SignInRequest;
 import com.hyerin.litebook.auth.thirdparty.dto.SignUpRequest;
 import com.hyerin.litebook.auth.thirdparty.kakao.api.KakaoAuthApiService;
@@ -20,12 +20,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KakaoAuthService implements SocialAuthService<SignUpRequest, SignInRequest> {
 
-	private static final String SESSION_LOGIN_KEY = "UID";
 	private static final String BAD_REQUEST = "BAD REQUEST : ";
 
 	private final KakaoAuthApiService kakaoAuthApiService;
 	private final UserService userService;
-	private final HttpSession httpSession;
+	private final LoginService sessionLoginService;
 
 	@Override
 	@Transactional
@@ -39,7 +38,7 @@ public class KakaoAuthService implements SocialAuthService<SignUpRequest, SignIn
 			.name(kakaoProfile.getKakaoAccount().getProfile().getNickname())
 			.profile(kakaoProfile.getKakaoAccount().getProfile().getProfileImageUrl())
 			.build();
-		
+
 		userService.signUp(user);
 	}
 
@@ -49,11 +48,11 @@ public class KakaoAuthService implements SocialAuthService<SignUpRequest, SignIn
 		User user = userService.getUser(request.getUid());
 
 		if (kakaoProfile.getId().equals(user.getUid())) {
-			httpSession.setAttribute(SESSION_LOGIN_KEY, user.getUid());
+			sessionLoginService.login(user.getUid());
 			return;
-		} else {
-			throw new IllegalArgumentException(BAD_REQUEST.concat(request.getUid()));
 		}
+		
+		throw new IllegalArgumentException(BAD_REQUEST.concat(request.getUid()));
 
 	}
 

--- a/src/main/java/com/hyerin/litebook/auth/thirdparty/service/SocialAuthService.java
+++ b/src/main/java/com/hyerin/litebook/auth/thirdparty/service/SocialAuthService.java
@@ -1,0 +1,12 @@
+package com.hyerin.litebook.auth.thirdparty.service;
+
+import com.hyerin.litebook.auth.thirdparty.dto.SignInRequest;
+import com.hyerin.litebook.auth.thirdparty.dto.SignUpRequest;
+
+public interface SocialAuthService<SIGNUP extends SignUpRequest, SIGNIN extends SignInRequest> {
+
+	void signUp(SIGNUP request);
+
+	void signIn(SIGNIN request) throws Exception;
+
+}

--- a/src/main/java/com/hyerin/litebook/common/dto/ResponseEntityConstants.java
+++ b/src/main/java/com/hyerin/litebook/common/dto/ResponseEntityConstants.java
@@ -1,0 +1,15 @@
+package com.hyerin.litebook.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityConstants {
+
+	private ResponseEntityConstants() {
+	}
+
+	public static final ResponseEntity<Void> CREATED = ResponseEntity.status(HttpStatus.CREATED).build();
+	public static final ResponseEntity<Void> OK = ResponseEntity.status(HttpStatus.OK).build();
+	public static final ResponseEntity<Void> BAD_REQUEST = ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+
+}

--- a/src/main/java/com/hyerin/litebook/configuration/WebClientConfig.java
+++ b/src/main/java/com/hyerin/litebook/configuration/WebClientConfig.java
@@ -1,0 +1,40 @@
+package com.hyerin.litebook.configuration;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.tcp.TcpClient;
+
+@Configuration
+public class WebClientConfig {
+
+	@Bean
+	public WebClient apiWebClient() {
+
+		final ReactorClientHttpConnector connector = new ReactorClientHttpConnector(
+			HttpClient.from(
+				TcpClient.create()
+					.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 3000)
+					.doOnConnected(conn ->
+						conn.addHandler(new ReadTimeoutHandler(3000, TimeUnit.MILLISECONDS))
+					)
+			)
+		);
+
+		return WebClient.builder()
+			.clientConnector(connector)
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+			.build();
+	}
+
+}

--- a/src/main/java/com/hyerin/litebook/user/domain/User.java
+++ b/src/main/java/com/hyerin/litebook/user/domain/User.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
 public class User {
 

--- a/src/main/java/com/hyerin/litebook/user/domain/User.java
+++ b/src/main/java/com/hyerin/litebook/user/domain/User.java
@@ -1,0 +1,35 @@
+package com.hyerin.litebook.user.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String uid;
+
+	private String name;
+
+	private String email;
+
+	private String profile;
+
+}

--- a/src/main/java/com/hyerin/litebook/user/repository/UserRepository.java
+++ b/src/main/java/com/hyerin/litebook/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.hyerin.litebook.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hyerin.litebook.user.domain.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByUid(String uid);
+}

--- a/src/main/java/com/hyerin/litebook/user/service/UserService.java
+++ b/src/main/java/com/hyerin/litebook/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.hyerin.litebook.user.service;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.hyerin.litebook.user.domain.User;
+import com.hyerin.litebook.user.repository.UserRepository;
+
+import javassist.NotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void signUp(User user) {
+		userRepository.save(user);
+	}
+
+	public User getUser(String uid) throws Exception {
+		return userRepository.findByUid(uid).orElseThrow(() -> new NotFoundException("회원가입이 필요한 사용자입니다."));
+	}
+
+}


### PR DESCRIPTION
### USER Entity
서비스에서 필요한 uid, name, profile image만 저장한다.

### sign up
회원 가입이 완료되면 uid와 함께 유저 정보 DB에 저장

### sign in
client에서 uid와 access token을 전달받아 kakao profile과 DB에서 USER 조회 후 비교

일치하면 session 로그인
불일치, not found 로그인 실패

blog : <https://hyerin6.github.io/2021-06-17/issue54/>  